### PR TITLE
Fix requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
       'opentsne',
       'seaborn',
       'scikit-learn',
-      'pandas'
+      'pandas',
+      'geomloss',
+      'munkres',
+      'adjustText',
     ],
     include_package_data=True,
     zip_safe=False


### PR DESCRIPTION
This minor fix is necessary for installing the `otdd` package from github using pip. These added packages seem to be sufficient, but feel free to add any other requirements I might have missed.