### PR TITLE
fix computing backend issue

### DIFF
--- a/otdd/pytorch/distance.py
+++ b/otdd/pytorch/distance.py
@@ -802,7 +802,7 @@ class DatasetDistance():
         W = self._get_label_distances().to(device)
 
         C = batch_augmented_cost(Z1.unsqueeze(0), Z2.unsqueeze(0),W=W).squeeze()
-        C = C.cpu()
+        C = C.cpu().numpy()
         if gpu is None:
             gpu = self.device != 'cpu'
         if 'method' in kwargs and kwargs['method'] == 'emd':

--- a/otdd/pytorch/wasserstein.py
+++ b/otdd/pytorch/wasserstein.py
@@ -321,7 +321,7 @@ def pwdist_exact(X1, Y1, X2=None, Y2=None, symmetric=False, loss='sinkhorn',
         )
     elif loss == 'wasserstein':
         def distance(Xa, Xb):
-            C = cost_function(Xa, Xb).cpu()
+            C = cost_function(Xa, Xb).cpu().numpy()
             return torch.tensor(ot.emd2(ot.unif(Xa.shape[0]), ot.unif(Xb.shape[0]), C))#, verbose=True)
     else:
         raise ValueError('Wrong loss')


### PR DESCRIPTION
These changes are for the issue: **All array should be from the same type/backend**

The change in `distance.py` is for the flow example provided in the README. Btw, to make the example works, change symsqrt_v2(A, func='symeig') to symsqrt_v2(A, func='svd') is necessary.
For the change in `wasserstein.py`, it addresses the situation when user switches `inner_ot_loss = 'sinkhorn' to inner_ot_loss = 'wasserstein'`