### PR TITLE
Solved RuntimeError: zero-dimensional tensor cannot be concatenated

### DIFF
--- a/otdd/pytorch/utils.py
+++ b/otdd/pytorch/utils.py
@@ -277,7 +277,10 @@ def load_full_dataset(data, targets=False, return_both_targets=False,
             Y.append(y.to(device).squeeze())
     X = torch.cat(X)
 
-    if collect_targets: Y = torch.cat(Y)
+    if collect_targets: 
+        if Y[-1].dim() == 0:
+            Y[-1] = Y[-1][None]
+        Y = torch.cat(Y)
 
     if targets == 'infer':
         logger.warning('Performing clustering')


### PR DESCRIPTION
When applying OTDD on a small dataset, it might happen that the last item of the labels might be of the form `tensor(k)` instead of `tensor([k])` with `k` a `torch.int64`. In such case, it would produce the following error:
`RuntimeError: zero-dimensional tensor (at position 1) cannot be concatenated`.

To avoid that, I created a dumb dimension for the last item.